### PR TITLE
[fix][doc]fix comments for exposeManagedLedgerMetricsInPrometheus field

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1395,7 +1395,7 @@ metricsBufferResponse=false
 # Enable producer level metrics. default is false
 exposeProducerLevelMetricsInPrometheus=false
 
-# Enable managed ledger metrics (aggregated by namespace). default is false
+# Enable managed ledger metrics (aggregated by namespace). default is true
 exposeManagedLedgerMetricsInPrometheus=true
 
 # Enable cursor level metrics. default is false


### PR DESCRIPTION
### Motivation

The default value of the exposeManagedLedgerMetricsInPrometheus field is true, but the comment says that the default value is false.

### Modifications

Correct the comment of exposeManagedLedgerMetricsInPrometheus field.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)