### PR TITLE
[clean][pom]remove unused scala-library.version from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,6 @@ flexible messaging model and an intuitive client API.</description>
     <elasticsearch-java.version>8.1.0</elasticsearch-java.version>
     <trino.version>363</trino.version>
     <scala.binary.version>2.13</scala.binary.version>
-    <scala-library.version>2.13.6</scala-library.version>
     <debezium.version>1.9.5.Final</debezium.version>
     <debezium.postgresql.version>42.5.0</debezium.postgresql.version>
     <debezium.mysql.version>8.0.30</debezium.mysql.version>


### PR DESCRIPTION
### Motivation
`scala-library.version` in pom.xml is no longer used.

### Modifications
remove unused `scala-library.version` from pom.xml

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
