### PR TITLE
[improve][broker] Add the logic for creating missed subscriptions for createMissedPartitions

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -4624,7 +4624,7 @@ public class PersistentTopicsBase extends AdminResource {
             });
         }).exceptionally(ex -> {
             if (ex.getCause() instanceof PulsarAdminException.NotFoundException) {
-                // The first partition doesn't exist, so there are currently to subscriptions to recreate
+                // The first partition doesn't exist, so there are currently to subscriptions no recreate
                 result.complete(null);
             } else {
                 log.warn("[{}] Failed to get list of subscriptions of {}",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -890,11 +890,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Specify the namespace", required = true)
             @PathParam("namespace") String namespace,
             @ApiParam(value = "Specify topic name", required = true)
-            @PathParam("topic") @Encoded String encodedTopic) {
-
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "List of subscriptions created for missed partitions") List<String> subscriptions) {
         try {
             validatePartitionedTopicName(tenant, namespace, encodedTopic);
-            internalCreateMissedPartitions(asyncResponse);
+            internalCreateMissedPartitions(asyncResponse, subscriptions);
         } catch (Exception e) {
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionCreationTest.java
@@ -25,7 +25,6 @@ import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.stats.TopicStatsImpl;
-import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.assertj.core.util.Lists;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -121,20 +120,20 @@ public class PartitionCreationTest extends ProducerConsumerBase {
     }
 
     @Test(timeOut = 60000, dataProvider = "restCreateMissedPartitions")
-    public void testCreateMissedPartitions(boolean useRestApi) throws PulsarAdminException, PulsarClientException, MetadataStoreException {
+    public void testCreateMissedPartitions(boolean useRestApi) throws Exception {
         conf.setAllowAutoTopicCreation(false);
         final String topic = "testCreateMissedPartitions-useRestApi-" + useRestApi;
-        final String group1 = "cg_testCreateMissedPartitions-1";
-        final String group2 = "cg_testCreateMissedPartitions-2";
+        final String sub1 = "sub-1";
+        final String sub2 = "sub-2";
         final TopicName topicName = TopicName.get(topic);
         int numPartitions = 3;
         // simulate partitioned topic without partitions
         pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
                 .createPartitionedTopicAsync(TopicName.get(topic),
-                new PartitionedTopicMetadata(numPartitions));
+                new PartitionedTopicMetadata(numPartitions)).get();
         Consumer<byte[]> consumer = null;
         try {
-            consumer = pulsarClient.newConsumer().topic(topic).subscriptionName(group1).subscribeAsync().get(3, TimeUnit.SECONDS);
+            consumer = pulsarClient.newConsumer().topic(topic).subscriptionName(sub1).subscribeAsync().get(3, TimeUnit.SECONDS);
         } catch (Exception e) {
             //ok here, consumer will create failed with 'Topic does not exist'
         }
@@ -146,7 +145,7 @@ public class PartitionCreationTest extends ProducerConsumerBase {
                 admin.topics().createNonPartitionedTopic(topicName.getPartition(i).toString());
             }
         }
-        consumer = pulsarClient.newConsumer().topic(topic).subscriptionName(group1).subscribe();
+        consumer = pulsarClient.newConsumer().topic(topic).subscriptionName(sub1).subscribe();
         Assert.assertNotNull(consumer);
         Assert.assertTrue(consumer instanceof MultiTopicsConsumerImpl);
         Assert.assertEquals(((MultiTopicsConsumerImpl)consumer).getConsumers().size(), numPartitions);
@@ -155,14 +154,14 @@ public class PartitionCreationTest extends ProducerConsumerBase {
         int newNumPartitions = 5;
         pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
                 .updatePartitionedTopicAsync(TopicName.get(topic),p ->
-                        new PartitionedTopicMetadata(newNumPartitions, p.properties));
+                        new PartitionedTopicMetadata(newNumPartitions, p.properties)).get();
 
         TopicStatsImpl topicStats;
         for (int i = 0; i < newNumPartitions; i++) {
             try {
                 topicStats = (TopicStatsImpl) admin.topics().getStats(topicName.getPartition(i).toString());
                 Assert.assertTrue(i < numPartitions);
-                Assert.assertTrue(topicStats.getSubscriptions().containsKey(group1));
+                Assert.assertTrue(topicStats.getSubscriptions().containsKey(sub1));
             } catch (PulsarAdminException ex) {
                 Assert.assertTrue(numPartitions <= i);
                 Assert.assertEquals(ex.getStatusCode(), Response.Status.NOT_FOUND.getStatusCode());
@@ -170,7 +169,7 @@ public class PartitionCreationTest extends ProducerConsumerBase {
         }
 
         if (useRestApi) {
-            admin.topics().createMissedPartitions(topic, Lists.newArrayList(group2));
+            admin.topics().createMissedPartitions(topic, Lists.newArrayList(sub2));
         } else {
             for (int i = numPartitions; i < newNumPartitions; i++) {
                 admin.topics().createNonPartitionedTopic(topicName.getPartition(i).toString());
@@ -181,9 +180,9 @@ public class PartitionCreationTest extends ProducerConsumerBase {
             topicStats = (TopicStatsImpl) admin.topics().getStats(topicName.getPartition(i).toString());
             Assert.assertNotNull(topicStats);
             if (useRestApi) {
-                Assert.assertTrue(i < numPartitions && topicStats.getSubscriptions().containsKey(group1) ||
-                        numPartitions <= i && !topicStats.getSubscriptions().containsKey(group1));
-                Assert.assertTrue(topicStats.getSubscriptions().containsKey(group2));
+                Assert.assertTrue(i < numPartitions && topicStats.getSubscriptions().containsKey(sub1) ||
+                        numPartitions <= i && !topicStats.getSubscriptions().containsKey(sub1));
+                Assert.assertTrue(topicStats.getSubscriptions().containsKey(sub2));
             }
         }
     }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -576,7 +576,21 @@ public interface Topics {
      *
      * @param topic partitioned topic name
      */
-    void createMissedPartitions(String topic) throws PulsarAdminException;
+    default void createMissedPartitions(String topic) throws PulsarAdminException {
+        createMissedPartitions(topic, null);
+    }
+
+    /**
+     * Create missed partitions for partitioned topic.
+     * <p/>
+     * When disable topic auto creation, use this method to try create missed partitions while
+     * partitions create failed or users already have partitioned topic without partitions.
+     *
+     * @param topic partitioned topic name
+     * @param subscriptions List of subscription
+     * @throws PulsarAdminException
+     */
+    void createMissedPartitions(String topic, List<String> subscriptions) throws PulsarAdminException;
 
     /**
      * Create missed partitions for partitioned topic asynchronously.
@@ -585,8 +599,9 @@ public interface Topics {
      * partitions create failed or users already have partitioned topic without partitions.
      *
      * @param topic partitioned topic name
+     * @param subscriptions List of subscription
      */
-    CompletableFuture<Void> createMissedPartitionsAsync(String topic);
+    CompletableFuture<Void> createMissedPartitionsAsync(String topic, List<String> subscriptions);
 
     /**
      * Update number of partitions of a non-global partitioned topic.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -309,8 +309,8 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public void createMissedPartitions(String topic) throws PulsarAdminException {
-        sync(() -> createMissedPartitionsAsync(topic));
+    public void createMissedPartitions(String topic, List<String> subscriptions) throws PulsarAdminException {
+        sync(() -> createMissedPartitionsAsync(topic, subscriptions));
     }
 
     @Override
@@ -344,10 +344,10 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public CompletableFuture<Void> createMissedPartitionsAsync(String topic) {
+    public CompletableFuture<Void> createMissedPartitionsAsync(String topic, List<String> subscriptions) {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "createMissedPartitions");
-        return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
+        return asyncPostRequest(path, Entity.entity(subscriptions, MediaType.APPLICATION_JSON));
     }
 
     @Override

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1627,7 +1627,11 @@ public class PulsarAdminToolTest {
         verify(mockTopics).createPartitionedTopic("persistent://myprop/clust/ns1/ds1", 32, null);
 
         cmdTopics.run(split("create-missed-partitions persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).createMissedPartitions("persistent://myprop/clust/ns1/ds1");
+        verify(mockTopics).createMissedPartitions("persistent://myprop/clust/ns1/ds1", null);
+
+        cmdTopics = new CmdTopics(() -> admin);
+        cmdTopics.run(split("create-missed-partitions persistent://myprop/clust/ns1/ds1 -s sub1,sub2"));
+        verify(mockTopics).createMissedPartitions("persistent://myprop/clust/ns1/ds1", Lists.newArrayList("sub1", "sub2"));
 
         cmdTopics.run(split("create persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).createNonPartitionedTopic("persistent://myprop/clust/ns1/ds1", null);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -559,10 +559,15 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = { "-s", "--subscriptions" }, description = "List of subscriptions to create")
+        private String subscriptions;
+
         @Override
         void run() throws Exception {
             String topic = validateTopicName(params);
-            getTopics().createMissedPartitions(topic);
+            List<String> subscriptionList =
+                    isNotBlank(subscriptions) ? Lists.newArrayList(subscriptions.split(",")) : null;
+            getTopics().createMissedPartitions(topic, subscriptionList);
         }
     }
 

--- a/site2/website/versioned_docs/version-2.10.x/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.10.x/admin-api-topics.md
@@ -1887,7 +1887,7 @@ admin.topics().createPartitionedTopic(topicName, numPartitions);
 
 ### Create missed partitions
 
-When topic auto-creation is disabled, and you have a partitioned topic without any partitions, you can use the [`create-missed-partitions`](reference-pulsar-admin.md#create-missed-partitions) command to create partitions for the topic.
+When topic auto-creation is disabled, and you have a partitioned topic without any partitions, you can use the [`create-missed-partitions`](reference-pulsar-admin.md#create-missed-partitions) command to create partitions for the topic, and you can also specify the subscription list to create subscriptions for all partitions of the topic.
 
 ````mdx-code-block
 <Tabs 
@@ -1895,12 +1895,14 @@ When topic auto-creation is disabled, and you have a partitioned topic without a
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
 <TabItem value="pulsar-admin">
 
-You can create missed partitions with the [`create-missed-partitions`](reference-pulsar-admin.md#create-missed-partitions) command and specify the topic name as an argument.
+When you create missed partitions with the [`create-missed-partitions`](reference-pulsar-admin.md#create-missed-partitions)
+command,you need to specify the topic name as an argument, and use the `-s` or `--subscriptions` flag to selectively specify the subscription list to create.
 
 ```shell
 
 $ bin/pulsar-admin topics create-missed-partitions \
   persistent://my-tenant/my-namespace/my-topic \
+  --subscriptions my-subscription-1,my-subscription-2
 
 ```
 
@@ -1915,7 +1917,8 @@ $ bin/pulsar-admin topics create-missed-partitions \
 ```java
 
 String topicName = "persistent://my-tenant/my-namespace/my-topic";
-admin.topics().createMissedPartitions(topicName);
+String subscriptionName = "my-subscription";
+admin.topics().createMissedPartitions(topicName, Lists.newArrayList(subscriptionName));
 
 ```
 


### PR DESCRIPTION
### Motivation
`org.apache.pulsar.broker.admin.impl.PersistentTopicsBase#internalCreateMissedPartitions` lacks the logic to create subscriptions.

### Modifications
 - add `org.apache.pulsar.broker.admin.impl.PersistentTopicsBase#createMissedSubscriptionsAsync`
 - add the logic for creating missed subscriptions for `org.apache.pulsar.broker.admin.impl.PersistentTopicsBase#internalCreateMissedPartitions`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-complete` <!-- Docs have been already added -->

