### PR TITLE
[improve][broker]optimize the log printing logic of PulsarService

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -902,9 +902,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     + (config.getWebServicePortTls().isPresent() ? ", tls-port = " + config.getWebServicePortTls() : "")
                     + (StringUtils.isNotEmpty(brokerServiceUrl) ? ", broker url= " + brokerServiceUrl : "")
                     + (StringUtils.isNotEmpty(brokerServiceUrlTls) ? ", broker tls url= " + brokerServiceUrlTls : "");
-            LOG.info("messaging service is ready, bootstrap_seconds={}", bootstrapTimeSeconds);
-            LOG.info("messaging service is ready, {}, cluster={}, configs={}", bootstrapMessage,
-                    config.getClusterName(), config);
+            LOG.info("messaging service is ready, {}, cluster={}, configs={}, bootstrap_seconds={}", bootstrapMessage,
+                    config.getClusterName(), config, bootstrapTimeSeconds);
 
             state = State.Started;
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -902,8 +902,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     + (config.getWebServicePortTls().isPresent() ? ", tls-port = " + config.getWebServicePortTls() : "")
                     + (StringUtils.isNotEmpty(brokerServiceUrl) ? ", broker url= " + brokerServiceUrl : "")
                     + (StringUtils.isNotEmpty(brokerServiceUrlTls) ? ", broker tls url= " + brokerServiceUrlTls : "");
-            LOG.info("messaging service is ready, {}, cluster={}, configs={}, bootstrap_seconds={}", bootstrapMessage,
-                    config.getClusterName(), config, bootstrapTimeSeconds);
+            LOG.info("messaging service is ready, bootstrap_seconds={}, {}, cluster={}, configs={}",
+                    bootstrapTimeSeconds, bootstrapMessage, config.getClusterName(), config);
 
             state = State.Started;
         } catch (Exception e) {


### PR DESCRIPTION
### Motivation
In `org.apache.pulsar.broker.PulsarService#start`, two log printing can be combined into one line.
https://github.com/Pomelongan/pulsar/blob/b7b923933a5c7594a52c8bb761f80e25ca0065cb/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java#L905-L907
### Modifications
Combine the two log lines in the `org.apache.pulsar.broker.PulsarService#start` into one line.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->